### PR TITLE
FIX compilation errors

### DIFF
--- a/srcclock1.0/source/csrc.cpp
+++ b/srcclock1.0/source/csrc.cpp
@@ -234,7 +234,7 @@ int Csrc::parity(int beg, int end) const
 void Csrc::set_today()
 {
   struct tm ttmm;
-  time_t tt = time('\0');
+  time_t tt = time(NULL);
   localtime_r(&tt, &ttmm);
 //               struct tm {
 //                   int tm_sec;         /* seconds */
@@ -660,7 +660,7 @@ int Csrc::setWDS(int Wlength, double snr)
     adaptive_decision_threshold = true;
   }
 
-  snr_level = pow10(snr/10);
+  snr_level = exp10(snr/10);
 
   if(verbose_level >= 2) lout <<"WDS. New window length: " <<window_length <<" symbols; SNR: " <<10*log10(snr_level) <<" dB\n";
 
@@ -1485,7 +1485,7 @@ bool Csrc::set(const struct tm& ttmm)
 bool Csrc::set(const char* strDate, const char* format)
 {
   tm ttmm;
-  time_t tt = time('\0');
+  time_t tt = time(NULL);
   localtime_r(&tt, &ttmm);		// initialize the ttmm to the current date/time
 
   strptime(strDate, format, &ttmm);	// convert a string to a struct tm

--- a/srcclock1.0/source/main.cpp
+++ b/srcclock1.0/source/main.cpp
@@ -143,10 +143,10 @@ int main(int argc, char **argv) {
   options.wds = 50;
   options.snr_level = 5.0;	// 5 dB SNR default
   
-  options.fo = '\0';
-  options.soundDev = '\0';	// default sound device
-  options.logfile = '\0';
-  options.setDate = '\0';
+  options.fo = NULL;
+  options.soundDev = NULL;	// default sound device
+  options.logfile = NULL;
+  options.setDate = NULL;
   options.repeat = 1;
   options.SRCaction = 0;
   options.delay = 1;


### PR DESCRIPTION
It wasn't compiling on my system. Now it works, with small changes, which I think is good.

I replaced the `pow10` function (which was unknown on my system) with the `exp10` which, according to [the manual](http://man7.org/linux/man-pages/man3/pow10.3.html)
> should be used in preference